### PR TITLE
classes for api key and url

### DIFF
--- a/lib/api_url.dart
+++ b/lib/api_url.dart
@@ -1,0 +1,3 @@
+class ApiUrl{
+  static final String BASE_URL = 'https://owlbot.info/api/v4/dictionary/';
+}

--- a/lib/key.dart
+++ b/lib/key.dart
@@ -1,0 +1,3 @@
+class ApiKey{
+  static final KEY = 'Authorization token here';
+}

--- a/lib/network/api_methods.dart
+++ b/lib/network/api_methods.dart
@@ -1,0 +1,27 @@
+import 'package:jisho/model/word_model.dart';
+import 'package:jisho/network/i_client.dart';
+import 'package:jisho/network/rest_api_service.dart';
+
+abstract class ApiMethods{
+  Future<WordDefinition> getWordDefinition(String url, Map<String, dynamic> queryParams);
+}
+
+class GetWord extends ApiMethods{
+  IClient _iClient;
+
+  GetWord(){
+    _iClient = RestApiService();
+  }
+
+  @override
+  Future<WordDefinition> getWordDefinition(String url, Map<String, dynamic> queryParams) async {
+    var result = await _iClient.getAsync(url, queryParams);
+    if(result.networkServiceResponse.success){
+      WordDefinition wordDefinition = WordDefinition.fromJson(result.mappedResult);
+      return wordDefinition;
+    } else {
+      throw Exception(result.networkServiceResponse.message);
+    }
+  }
+
+}

--- a/lib/network/rest_api_service.dart
+++ b/lib/network/rest_api_service.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+import 'package:dio/dio.dart';
+import 'package:jisho/network/i_client.dart';
+import 'package:jisho/network/service_response.dart';
+
+class RestApiService extends IClient{
+
+  @override
+  Future<MappedNetworkServiceResponse<T>> getAsync<T>(String url, Map<String, dynamic> queryParams) async {
+    Response response = await Dio().get(url, queryParameters: queryParams);
+
+    return await processResponse<T>(response);
+  }
+
+  Future<MappedNetworkServiceResponse<T>> processResponse<T>(Response response) async{
+    try{
+      if(!((response.statusCode < HttpStatus.ok) ||
+          (response.statusCode >= HttpStatus.multipleChoices) ||
+          (response.data == null))){
+
+          return MappedNetworkServiceResponse<T>(
+            mappedResult: response.data,
+            networkServiceResponse: NetworkServiceResponse<T>(
+              success: true,
+            )
+          );
+      } else {
+        var error = response.data;
+        return MappedNetworkServiceResponse<T>(
+          networkServiceResponse: NetworkServiceResponse<T>(
+            success: false,
+            message: "${response.statusCode} ${error.toString()}"
+          )
+        );
+      }
+
+    } on SocketException catch(_){
+      return MappedNetworkServiceResponse<T>(
+        networkServiceResponse: NetworkServiceResponse<T>(
+          success: false,
+          message: "${response.statusCode} Check your Internet Connection"
+        )
+      );
+    }
+  }
+
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   dio: 3.0.10
+  bloc: 7.0.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-
+  dio: 3.0.10
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Created different classes for API url and the key/token. we will use `ApiKey.KEY` to pass our token in our API calls. 
We will also use `ApiUrl.BASE_URL`  in the `url` parameters in our Bloc Event. 

**Only merge this after #12 is merged**